### PR TITLE
Initialize Chrome extension helper project

### DIFF
--- a/chrome-extension-helper/.gitignore
+++ b/chrome-extension-helper/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/chrome-extension-helper/index.html
+++ b/chrome-extension-helper/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Popup</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/popup/main.tsx"></script>
+  </body>
+</html>

--- a/chrome-extension-helper/options.html
+++ b/chrome-extension-helper/options.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Options</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/options/main.tsx"></script>
+  </body>
+</html>

--- a/chrome-extension-helper/package.json
+++ b/chrome-extension-helper/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "chrome-extension-helper",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/chrome": "^0.0.276",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.11",
+    "@vitejs/plugin-react": "^4.2.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/chrome-extension-helper/public/manifest.json
+++ b/chrome-extension-helper/public/manifest.json
@@ -1,0 +1,22 @@
+{
+  "manifest_version": 3,
+  "name": "Chrome Extension Helper",
+  "version": "0.1.0",
+  "action": {
+    "default_popup": "index.html"
+  },
+  "options_page": "options.html",
+  "background": {
+    "service_worker": "src/background/background.ts",
+    "type": "module"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["src/content/content.ts"],
+      "run_at": "document_end"
+    }
+  ],
+  "permissions": ["storage", "activeTab", "scripting"],
+  "host_permissions": ["<all_urls>"]
+}

--- a/chrome-extension-helper/src/background/background.ts
+++ b/chrome-extension-helper/src/background/background.ts
@@ -1,0 +1,3 @@
+chrome.runtime.onInstalled.addListener(() => {
+  console.log('Extension installed');
+});

--- a/chrome-extension-helper/src/content/content.ts
+++ b/chrome-extension-helper/src/content/content.ts
@@ -1,0 +1,12 @@
+console.log('Content script loaded');
+
+document.addEventListener('DOMContentLoaded', () => {
+  const forms = document.querySelectorAll('form');
+  forms.forEach((form) => {
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.name = 'auto-field';
+    input.value = 'autofilled';
+    form.appendChild(input);
+  });
+});

--- a/chrome-extension-helper/src/options/Options.tsx
+++ b/chrome-extension-helper/src/options/Options.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import { loadSettings, saveSettings } from '../utils/storage';
+import type { Settings } from '../types';
+
+export function Options() {
+  const [form, setForm] = useState<Settings>({ apiUrl: '', token: '' });
+  const [status, setStatus] = useState('');
+
+  useEffect(() => {
+    loadSettings().then((settings) => {
+      if (settings) setForm(settings);
+    });
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await saveSettings(form);
+    setStatus('Saved');
+  };
+
+  return (
+    <form onSubmit={handleSave}>
+      <label>
+        API URL:
+        <input name="apiUrl" value={form.apiUrl} onChange={handleChange} />
+      </label>
+      <label>
+        Token:
+        <input name="token" value={form.token} onChange={handleChange} />
+      </label>
+      <button type="submit">Save</button>
+      {status && <span>{status}</span>}
+    </form>
+  );
+}
+
+export default Options;

--- a/chrome-extension-helper/src/options/main.tsx
+++ b/chrome-extension-helper/src/options/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import Options from './Options';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <Options />
+  </React.StrictMode>
+);

--- a/chrome-extension-helper/src/popup/Popup.tsx
+++ b/chrome-extension-helper/src/popup/Popup.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { loadSettings } from '../utils/storage';
+
+export function Popup() {
+  const [message, setMessage] = useState('');
+  const [response, setResponse] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadSettings().then((settings) => {
+      if (settings) {
+        setMessage(`Settings loaded: ${JSON.stringify(settings)}`);
+      }
+    });
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    const url = formData.get('url') as string;
+    try {
+      const res = await fetch(url, { method: 'GET' });
+      const text = await res.text();
+      setResponse(text.slice(0, 100));
+    } catch (err) {
+      setResponse(`Error: ${String(err)}`);
+    }
+  };
+
+  return (
+    <div>
+      <h1>Helper</h1>
+      {message && <p>{message}</p>}
+      <form onSubmit={handleSubmit}>
+        <input name="url" placeholder="Request URL" />
+        <button type="submit">Send</button>
+      </form>
+      {response && <pre>{response}</pre>}
+    </div>
+  );
+}
+
+export default Popup;

--- a/chrome-extension-helper/src/popup/main.tsx
+++ b/chrome-extension-helper/src/popup/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import Popup from './Popup';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <Popup />
+  </React.StrictMode>
+);

--- a/chrome-extension-helper/src/types/index.ts
+++ b/chrome-extension-helper/src/types/index.ts
@@ -1,0 +1,4 @@
+export interface Settings {
+  apiUrl: string;
+  token: string;
+}

--- a/chrome-extension-helper/src/utils/storage.ts
+++ b/chrome-extension-helper/src/utils/storage.ts
@@ -1,0 +1,26 @@
+import type { Settings } from '../types';
+
+export const STORAGE_KEY = 'extension-settings';
+
+export async function saveSettings(settings: Settings): Promise<void> {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.set({ [STORAGE_KEY]: settings }, () => {
+      const err = chrome.runtime.lastError;
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
+export async function loadSettings(): Promise<Settings | null> {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.get([STORAGE_KEY], (result) => {
+      const err = chrome.runtime.lastError;
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(result[STORAGE_KEY] ?? null);
+    });
+  });
+}

--- a/chrome-extension-helper/src/vite-env.d.ts
+++ b/chrome-extension-helper/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/chrome-extension-helper/test/storage.test.ts
+++ b/chrome-extension-helper/test/storage.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest';
+import { saveSettings, loadSettings, STORAGE_KEY } from '../src/utils/storage';
+import type { Settings } from '../src/types';
+
+const mockStorage: Record<string, unknown> = {};
+
+vi.stubGlobal('chrome', {
+  storage: {
+    local: {
+      set: (items: Record<string, unknown>, cb: () => void) => {
+        Object.assign(mockStorage, items);
+        cb();
+      },
+      get: (_keys: string[], cb: (items: Record<string, unknown>) => void) => {
+        cb(mockStorage as Record<string, unknown>);
+      }
+    }
+  },
+  runtime: {
+    lastError: undefined
+  }
+});
+
+describe('storage utils', () => {
+  it('saves and loads settings', async () => {
+    const s: Settings = { apiUrl: 'a', token: 'b' };
+    await saveSettings(s);
+    const res = await loadSettings();
+    expect(res).toEqual(s);
+    expect(mockStorage[STORAGE_KEY]).toEqual(s);
+  });
+});

--- a/chrome-extension-helper/tsconfig.json
+++ b/chrome-extension-helper/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vitest/globals"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/chrome-extension-helper/tsconfig.node.json
+++ b/chrome-extension-helper/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/chrome-extension-helper/vite.config.ts
+++ b/chrome-extension-helper/vite.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: {
+        popup: resolve(__dirname, 'index.html'),
+        options: resolve(__dirname, 'options.html'),
+        background: resolve(__dirname, 'src/background/background.ts')
+      },
+      output: {
+        entryFileNames: 'assets/[name].js',
+        chunkFileNames: 'assets/[name].js',
+        assetFileNames: 'assets/[name][extname]'
+      }
+    }
+  }
+});

--- a/chrome-extension-helper/vitest.config.ts
+++ b/chrome-extension-helper/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom'
+  }
+});


### PR DESCRIPTION
## Summary
- set up Vite + React + TypeScript project for a Chrome extension
- add popup and options React interfaces
- implement content and background scripts
- add utility wrapper around `chrome.storage`
- create manifest (MV3)
- provide Vitest config and basic tests for the storage util

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68839a985c148326a76c4e9f589e9169